### PR TITLE
fix: Fixed config example in README

### DIFF
--- a/Modules/VIP_Items/README.md
+++ b/Modules/VIP_Items/README.md
@@ -48,16 +48,6 @@ Add the items feature to your `vip_groups.jsonc` file:
             ]
           }
         }
-      },
-      "SILVER": {
-        "Values": {
-          "vip.items": {
-            "Weapons": [
-              "weapon_m4a1",
-              "weapon_flashbang"
-            ]
-          }
-        }
       }
     }
   }


### PR DESCRIPTION
There was a config example mistake of an old version of VIP_Items which didn't have per-team config.